### PR TITLE
Fix assert! macro usage

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -307,7 +307,7 @@ fn test_at() {
 		error = true;
 		assert_eq!(e, IndexOutOfBounds);
 	}
-	assert!(error;);
+	assert!(error);
 }
 
 #[test]


### PR DESCRIPTION
There is a bug in rustc that allows adding invalid trailing tokens to the `assert!` macro call. They are currently ignored but are going to produce errors in the future.

Fix assert! macro usage to remove extra tokens.

For more information, see https://github.com/rust-lang/rust/issues/60024 and https://github.com/rust-lang/rust/pull/60039
